### PR TITLE
Update WC version check to 3.6.4

### DIFF
--- a/src/Bootstrapper.php
+++ b/src/Bootstrapper.php
@@ -191,10 +191,10 @@ class Bootstrapper
             return false;
         }
 
-        if (version_compare(wc()->version, '3.2.0', '<')) {
+        if (version_compare(wc()->version, '3.6.4', '<')) {
             $this->adminNotice(
                 __(
-                    'PayPal PLUS requires WooCommerce version 3.2 or higher.',
+                    'PayPal PLUS requires WooCommerce version 3.6.4 or higher.',
                     'woo-paypalplus'
                 )
             );


### PR DESCRIPTION
PPP-414
To be coherent with the plugin's header and the installation
requirements
on Wordpress.org we check for WooCommerce version 3.6.4 instead of 3.2.0