### PR TITLE
Fixed unable to match orders; hyphens are removed from invoice_number sent to PayPal.

### DIFF
--- a/src/Payment/PatchProvider.php
+++ b/src/Payment/PatchProvider.php
@@ -69,7 +69,7 @@ class PatchProvider
      */
     public function invoice($invoice_prefix)
     {
-        $invoice_number = preg_replace('/[^a-zA-Z0-9]/', '', $this->order->get_order_number());
+        $invoice_number = preg_replace('/[^[:print:]]/', '', $this->order->get_order_number());
 
         $invoice_patch = new Patch();
         $invoice_patch


### PR DESCRIPTION
Problem
- The invoice_number sent to PayPal has all hyphens removed. When trying to match PayPal transactions against shop orders for financial bookkeeping, the mapping cannot be established.

Details
- The woo-paypalplus plugin removes any characters that are not characters and numbers:
https://github.com/inpsyde/paypal-plus-plugin/blob/9b706bdd01767249c79f5492518c2d7d19f64f3a/src/Payment/PatchProvider.php#L70-L80

- However, this diverges from the PayPal API, which only defines the parameter `invoice_number` to be restricted to single byte characters:
https://developer.paypal.com/docs/api/payments/v1/#definition-capture
(search for "invoice_number" and step through results; not all of them have the complete definition; also note that this definition did not change in v2)
    > The invoice number that tracks this payment. Value is a string of single-byte alphanumeric characters. Maximum length: 127.

- A single-byte character set most commonly refers to [ISO 8859-1](https://en.wikipedia.org/wiki/ISO/IEC_8859-1).  It actually allows for further special characters including accents and e.g. the German sharp-S, but most notably not the Euro currency sign.

- However, to keep things simple, we can disregard those and simply limit to the range to ASCII printable characters – which is still less than what seems to be supported by the PayPal API, but resolves the problem.

Proposed solution
1. The most efficient way to limit the string to ASCII printable characters is by using `":print:"` character class in PCRE, as discussed in e.g. https://stackoverflow.com/a/28970891/811306 and https://stackoverflow.com/a/57871683/811306. A quick test confirms:

```
$ php -r 'var_dump(preg_replace("@[^[:print:]]@", "", "Euro € ißt Bitcöin 🐶\nwau-wau"));'
string(23) "Euro  it Bitcin wau-wau"
```
(The spaces are part of the input string, so also expected in the output string. We can safely assume that an actual order/invoice number will not have spaces in it.)