### PR TITLE
Fix stderr: parent was called incorrectly.

### DIFF
--- a/src/Payment/CartItemData.php
+++ b/src/Payment/CartItemData.php
@@ -83,7 +83,7 @@ class CartItemData implements OrderItemDataProvider
         $product = $this->data['data'];
         $sku = $product->get_sku();
         if ($product instanceof \WC_Product_Variation) {
-            $sku = $product->parent->get_sku();
+            $sku = $product->get_parent_data()['sku'];
         }
 
         return $sku;


### PR DESCRIPTION
Hi there,

One got annoyed by the following warning: 

` Produkteigenschaften sollten nicht direkt abgerufen werden. Backtrace: require('wp-blog-header.php'), require_once('wp-includes/template-loader.php'), do_action('template_redirect'), WP_Hook->do_action, WP_Hook->apply_filters, WC_AJAX::do_wc_ajax, do_action('wc_ajax_update_order_review'), WP_Hook->do_action, WP_Hook->apply_filters, WC_AJAX::update_order_review, woocommerce_checkout_payment, wc_get_template, include('/plugins/woocommerce/templates/checkout/payment.php'), wc_get_template, include('/plugins/woocommerce/templates/checkout/payment-method.php'), WCPayPalPlus\\PlusGateway\\Gateway->payment_fields, WCPayPalPlus\\PlusGateway\\Gateway->form, WCPayPalPlus\\PlusGateway\\Gateway->createPayment, WCPayPalPlus\\Payment\\PaymentCreator->create, WCPayPalPlus\\Payment\\PaymentCreator->payment, WCPayPalPlus\\Payment\\PaymentCreator->details, WCPayPalPlus\\Payment\\CartData->subTotal, WCPayPalPlus\\Payment\\CartData->itemsList, WCPayPalPlus\\Payment\\CartData->item, WCPayPalPlus\\Payment\\CartItemData->get_sku, WC_Abstract_Legacy_Product->__get, wc_doing_it_wrong. This message was added in version 3.0., referer:`